### PR TITLE
Changes to IPF scraper to expose versioning and stop stall during scihub query 

### DIFF
--- a/AOI_based_ipf_submitter.py
+++ b/AOI_based_ipf_submitter.py
@@ -84,7 +84,7 @@ def get_non_ipf_acquisitions(location, start_time, end_time):
     return acq_list
 
 
-def submit_ipf_scraper(acq):
+def submit_ipf_scraper(acq, release):
     params = [
         {
             "name": "acq_id",
@@ -113,7 +113,7 @@ def submit_ipf_scraper(acq):
     print('submitting jobs with params:')
     print(json.dumps(params, sort_keys=True, indent=4, separators=(',', ': ')))
     mozart_job_id = submit_mozart_job({}, rule, hysdsio={"id": "internal-temporary-wiring", "params": params,
-                                                         "job-specification": "job-ipf_scraper:master"},
+                                                         "job-specification": "job-ipf_scraper:{}".format(release)},
                                       job_name='job-%s-%s-%s' % ("ipf_scraper", acq.get("id"), "master"),
                                       enable_dedup=False)
     print("For {} , IPF scrapper Job ID: {}".format(acq.get("id"), mozart_job_id))
@@ -129,6 +129,7 @@ if __name__ == "__main__":
     location = ctx.get("spatial_extent")
     start_time = ctx.get("start_time")
     end_time = ctx.get("end_time")
+    ipf_scraper_release = ctx.get("ipf_scraper_release")
     acqs_list = get_non_ipf_acquisitions(location, start_time, end_time)
     for acq in acqs_list:
-        submit_ipf_scraper(acq)
+        submit_ipf_scraper(acq, ipf_scraper_release)

--- a/docker/hysds-io.json.AOI_based_ipf_submitter
+++ b/docker/hysds-io.json.AOI_based_ipf_submitter
@@ -18,6 +18,13 @@
     {
         "name": "end_time",
         "from": "dataset_jpath:_source.endtime"
+    },
+    {
+        "name": "ipf_scraper_release",
+        "from": "submitter",
+        "type": "jobspec_version",
+        "version_regex": "job-ipf_scraper",
+        "placeholder": "ipf scraper version"
     }
   ]
 }

--- a/docker/job-spec.json.AOI_based_ipf_submitter
+++ b/docker/job-spec.json.AOI_based_ipf_submitter
@@ -25,6 +25,10 @@
     {
       "name": "end_time",
       "destination": "context"
+    },
+    {
+      "name": "ipf_scraper_release",
+      "destination": "context"
     }
   ]
 }

--- a/ipf_global_cron.py
+++ b/ipf_global_cron.py
@@ -28,7 +28,14 @@ def submit_global_ipf(spatial_extent, start_time, end_time, release):
             "name": "end_time",
             "from": "value",
             "value": end_time
+        },
+        {
+            "name": "ipf_scraper_release",
+            "from": "value",
+            "value": release
         }
+
+
     ]
 
     rule = {

--- a/ipf_version.py
+++ b/ipf_version.py
@@ -59,8 +59,8 @@ def get_scihub_manifest(session, info):
                                                                              info['met']['filename'])
     manifest_url2 = manifest_url.replace('/apihub/', '/dhus/')
     for url in (manifest_url2, manifest_url):
+        logger.info("url: %s" % url)
         response = session.get(url, verify=False, timeout=180)
-        logger.info("url: %s" % response.url)
         if response.status_code == 200:
             break
     response.raise_for_status()

--- a/ipf_version.py
+++ b/ipf_version.py
@@ -59,7 +59,7 @@ def get_scihub_manifest(session, info):
                                                                              info['met']['filename'])
     manifest_url2 = manifest_url.replace('/apihub/', '/dhus/')
     for url in (manifest_url2, manifest_url):
-        logger.info("url: %s" % url)
+        logger.info("querying scihub url: %s" % url)
         response = session.get(url, verify=False, timeout=180)
         if response.status_code == 200:
             break
@@ -134,6 +134,7 @@ def extract_asf_ipf(id):
 
 
 def update_ipf(id, ipf_version):
+    logger.info("Updating IPF Version of {}. IPF Version: {}".format(id, ipf_version))
     ES.update(index=_index, doc_type=_type, id=id,
               body={"doc": {"metadata": {"processing_version": ipf_version}}})
 


### PR DESCRIPTION
Changes to IPF scraper to expose versioning and stop stall during scihub query

1. expose release in AOI_based_ipf_submitter job so we can configure ipf_scraper job's release to run on (currently hardcoded to master)

2. If ipf_scraper falls back to Scihub, hitting the product scihub downlaod url [here](https://github.com/hysds/scihub_acquisition_scraper/blob/master/ipf_version.py#L39) to check if prod_available (due to Long term Archive). However, if product is online, we will hit cause`SoftTimeLimit exceeded` as the request attempts to download the SLC which takes a long time:
![image](https://user-images.githubusercontent.com/6346909/55153448-6ea42300-518d-11e9-9975-606c3f62e957.png)

The `requests` timeout does not work either since it is receiving bytes from server. 
Issue is prevalent when ipf_scraper attempts to scrape IPF for the latest acquisitions which ASF does not have the SLC online yet... (when cron is trigerred)

Changed logic to:
      i) check if product is online by checking product entry xml 
      ii) if product is online, proceed to extract manifest
      iii) if product is not online, proceed to hit download_url to make it online for later (should return 202), exit with Exception

Tests:
1. Fall back to Scihub if ASF does not have SLC yet: [gist](https://gist.github.com/shitong01/4a5efaf610191aa0b4c04cac2bbb220c#file-00-asf-down-using-scihub-backup)
2. If ASF is down, Scihub's in LongTermArchive:  [gist](https://gist.github.com/shitong01/4a5efaf610191aa0b4c04cac2bbb220c#file-01-asf-down-scihub-in-lta)

PR for consideration? @NamrataM @pymonger 