### PR TITLE
Better way of implementing IPF scraper to stop stall during scihub query

### DIFF
--- a/ipf_version.py
+++ b/ipf_version.py
@@ -126,6 +126,7 @@ def extract_asf_ipf(id):
 
 
 def update_ipf(id, ipf_version):
+    logger.info("Updating IPF Version of {}. IPF Version: {}".format(id, ipf_version))
     ES.update(index=_index, doc_type=_type, id=id,
               body={"doc": {"metadata": {"processing_version": ipf_version}}})
 

--- a/ipf_version.py
+++ b/ipf_version.py
@@ -36,7 +36,11 @@ def check_prod_avail(session, link):
     """
 
     product_url = "{}$value".format(link)
+<<<<<<< HEAD
     response = session.get(product_url, verify=False, timeout=180)
+=======
+    response = session.head(product_url, verify=False, timeout=180)
+>>>>>>> 764df39... better way of dealing with soft time limit exceeded
     return response.status_code
 
 

--- a/ipf_version.py
+++ b/ipf_version.py
@@ -36,11 +36,7 @@ def check_prod_avail(session, link):
     """
 
     product_url = "{}$value".format(link)
-<<<<<<< HEAD
-    response = session.get(product_url, verify=False, timeout=180)
-=======
     response = session.head(product_url, verify=False, timeout=180)
->>>>>>> 764df39... better way of dealing with soft time limit exceeded
     return response.status_code
 
 


### PR DESCRIPTION
Same issue as Closed PR detailed in [#3 Changes to IPF scraper to expose versioning and stop stall during scihub query](https://github.com/hysds/scihub_acquisition_scraper/pull/3).

Similar to PR [here](https://github.com/earthobservatory/scihub_acquisition_scraper/pull/6
) that reverted #3 and implement `requests.head` (merged to EOS' repo)

If ipf_scraper falls back to Scihub, we will hit the product url scihub download with `requests.get`. However, if product is online, we will hit causeSoftTimeLimit exceeded as the request attempts to download the SLC which takes a long time:
![image](https://user-images.githubusercontent.com/6346909/56780079-7dbfd480-6810-11e9-8339-f05ac32307c9.png)

This time, using a more elegant`requests.head` method which will not attempt to wait for download and return the status code. 

[Gists](https://gist.github.com/shitong01/0053cc048775d27c6d13cf03a4cf395c) from running system. Cases:
1. If Scihub takes too long to respond, we get timeout errors
2. When IPF scraping succeeds

@NamrataM @hookhua @pymonger 