### PR TITLE
ARIA-23: Make IPF scrapers error out with more exact causes for improved mozart trigger rules

### DIFF
--- a/ipf_version.py
+++ b/ipf_version.py
@@ -118,11 +118,11 @@ def extract_asf_ipf(id):
         logger.info("Response from ASF: {}".format(response.text))
         # download the .iso.xml file, assumes earthdata login credentials are in your .netrc file
         if len(results[0]) == 0:
-            raise Exception("Acquisition {} not found at ASF.".format(id))
+            raise Exception("Acquisition not found at ASF.")
         response = requests.get(results[0][0]['downloadUrl'])
         response.raise_for_status()
         if response.status_code != 200:
-            raise Exception("Request to ASF failed with status {}. {}".format(response.status_code, request_string))
+            raise Exception("Request to ASF failed with status {}.".format(response.status_code))
         # parse the xml file to extract the ipf version string
         root = fromstring(response.text.encode('utf-8'))
         ns = {'gmd': 'http://www.isotc211.org/2005/gmd', 'gmi': 'http://www.isotc211.org/2005/gmi',
@@ -194,7 +194,7 @@ if __name__ == "__main__":
     if check_ipf_avail(id):
         logger.error("Acquisition already has IPF, not processing with scraping")
         with open('_alt_error.txt', 'w') as f:
-            f.write("Acquisition already has IPF, not processing with scraping for {}".format(id))
+            f.write("Acquisition already has IPF, not proceeding with scraping for {}".format(id))
             f.close()
         sys.exit(1)
     
@@ -207,8 +207,8 @@ if __name__ == "__main__":
                 with open('_alt_error.txt', 'w') as f:
                     f.write("{}".format(ex))
                 with open('_alt_traceback.txt', 'w') as f:
-                    f.write("%s\n" % traceback.format_exc())
-                raise Exception("{}.".format(ex))
+                    f.write("Failed to get IPF for {}. \n{}. \n {}".format(id, ex, traceback.format_exc()))
+                raise Exception("Failed to get IPF for {}. {}.".format(id, ex))
     else:
         try:
             ipf = extract_scihub_ipf(met)
@@ -218,7 +218,7 @@ if __name__ == "__main__":
             with open('_alt_error.txt', 'w') as f:
                 f.write("{}".format(ex))
             with open('_alt_traceback.txt', 'w') as f:
-                f.write("%s\n" % traceback.format_exc())
-            raise Exception("{}.".format(ex))
+                f.write("Failed to get IPF for {}. \n{}. \n {}".format(id, ex, traceback.format_exc()))
+            raise Exception("Failed to get IPF for {}. {}.".format(id, ex))
 
     update_ipf(id, ipf)

--- a/ipf_version.py
+++ b/ipf_version.py
@@ -48,6 +48,7 @@ def check_prod_avail(session, link):
 
     product_url = "{}$value".format(link)
     response = session.head(product_url, verify=False, timeout=180)
+
     return response.status_code
 
 
@@ -116,6 +117,8 @@ def extract_asf_ipf(id):
         results = json.loads(response.text)
         logger.info("Response from ASF: {}".format(response.text))
         # download the .iso.xml file, assumes earthdata login credentials are in your .netrc file
+        if len(results[0]) == 0:
+            raise Exception("Acquisition {} not found at ASF.".format(id))
         response = requests.get(results[0][0]['downloadUrl'])
         response.raise_for_status()
         if response.status_code != 200:
@@ -124,14 +127,17 @@ def extract_asf_ipf(id):
         root = fromstring(response.text.encode('utf-8'))
         ns = {'gmd': 'http://www.isotc211.org/2005/gmd', 'gmi': 'http://www.isotc211.org/2005/gmi',
               'gco': 'http://www.isotc211.org/2005/gco'}
-        ipf_string = root.find(
-            'gmd:composedOf/gmd:DS_DataSet/gmd:has/gmi:MI_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:lineage/gmd:LI_Lineage/gmd:processStep/gmd:LI_ProcessStep/gmd:description/gco:CharacterString',
-            ns).text
+        try:
+            ipf_string = root.find(
+                'gmd:composedOf/gmd:DS_DataSet/gmd:has/gmi:MI_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:lineage/gmd:LI_Lineage/gmd:processStep/gmd:LI_ProcessStep/gmd:description/gco:CharacterString',
+                ns).text
+        except AttributeError:
+            raise Exception("Transient Error: IPF not found in XML from download URL")
         if ipf_string:
             ipf = ipf_string.split('version')[1].split(')')[0].strip()
     except Exception as err:
-        logger.info("get_processing_version_from_asf : %s" % str(err))
-        raise Exception("Error get_processing_version_from_asf : %s" % str(err))
+        logger.info("get_processing_version_from_asf: %s" % str(err))
+        raise Exception("{}".format(str(err)))
 
     return ipf
 
@@ -163,6 +169,9 @@ def extract_scihub_ipf(met):
     elif prod_avail == 202:
         logger.info("Got 202 from SciHub. Product moved to long term archive.")
         raise Exception("Got 202. Product moved to long term archive.")
+    elif prod_avail == 503:
+        logger.info("Exceeding max concurrent SciHub connections.")
+        raise Exception("Exceeding max concurrent SciHub connections.")
     else:
         logger.info("Got code {} from SciHub".format(prod_avail))
         raise Exception("Got code {}".format(prod_avail))
@@ -175,7 +184,7 @@ if __name__ == "__main__":
     '''
     Main program that find IPF version for acquisition
     '''
-    ctx = json.loads(open("_context.json","r").read())
+    ctx = json.loads(open("_context.json", "r").read())
     id = ctx["acq_id"]
     met = ctx["acq_met"]
     _index = ctx.get("index")
@@ -193,23 +202,23 @@ if __name__ == "__main__":
         try:
             ipf = extract_asf_ipf(met.get("identifier"))
             if ipf is None:
-                raise Exception
-        except Exception:
+                raise Exception("Found null IPF")
+        except Exception as ex:
                 with open('_alt_error.txt', 'w') as f:
-                    f.write("Failed to extract IPF version from ASF for {}".format(id))
+                    f.write("{}".format(ex))
                 with open('_alt_traceback.txt', 'w') as f:
                     f.write("%s\n" % traceback.format_exc())
-                raise Exception("Failed to extract IPF version from ASF for {}".format(id))
+                raise Exception("{}.".format(ex))
     else:
         try:
             ipf = extract_scihub_ipf(met)
             if ipf is None:
-                raise Exception
-        except Exception:
+                raise Exception("Found null IPF")
+        except Exception as ex:
             with open('_alt_error.txt', 'w') as f:
-                f.write("Failed to extract IPF version from SciHub for {}".format(id))
+                f.write("{}".format(ex))
             with open('_alt_traceback.txt', 'w') as f:
                 f.write("%s\n" % traceback.format_exc())
-            raise Exception("Failed to extract IPF version from SciHub for {}".format(id))
+            raise Exception("{}.".format(ex))
 
     update_ipf(id, ipf)

--- a/ipf_version.py
+++ b/ipf_version.py
@@ -132,7 +132,7 @@ def extract_asf_ipf(id):
                 'gmd:composedOf/gmd:DS_DataSet/gmd:has/gmi:MI_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:lineage/gmd:LI_Lineage/gmd:processStep/gmd:LI_ProcessStep/gmd:description/gco:CharacterString',
                 ns).text
         except AttributeError:
-            raise Exception("Transient Error: IPF not found in XML from download URL")
+            raise Exception("IPF not found in XML from download URL. Failed to extract IPF version from ASF.")
         if ipf_string:
             ipf = ipf_string.split('version')[1].split(')')[0].strip()
     except Exception as err:


### PR DESCRIPTION
Currently, ipf-scrapers are output generic "Failed to extract IPF version from" messages for most error types. We are unable to differentiate between serious error vs transient errors.

We currently see the following:
job-ipf-scraper-scihub:release-20190504
Failed to extract IPF version from SciHub for acquisition-Sentinel-*-esa_scihub

Job-ipf-scraper-asf:release-20190504
Failed to extract IPF version from ASF for acquisition-Sentinel-*-esa_scihub

Need to bubble up more exact errors encountered. Specifically if there is a non-200 http response, vs parsing error vs other errors.

Some root causes found in traceback that is currently hidden behind the "Failed to extract IPF version from":

Exception: Got code 503 (scihub, exceeding concurrent connections to scihub)

Exception: Error get_processing_version_from_asf : list index out of range (ASF may not have ingested this yet, or it may be deprecated)

Exception: Error get_processing_version_from_asf : 'NoneType' object has no attribute 'text' (could be transient; CMR may not be returning response to ASF)

For this task, please update with list of exceptions being outputted so that we can add appropriate figaro trigger rules to auto-handle the transient conditions.